### PR TITLE
CheckboxGroup to Dropdown

### DIFF
--- a/process_png_metadata.py
+++ b/process_png_metadata.py
@@ -150,7 +150,7 @@ class Script(scripts.Script):
                         output_dir = gr.Textbox(label="Output directory", **shared.hide_dirs, placeholder="Add output folder path or Leave blank to use default path.", elem_id="files_batch_output_dir")
                 
                 # CheckboxGroup with all parameters assignable from the input image (output is a list with the Name of the Checkbox checked ex: ["Checkpoint", "Prompt"]) 
-                options = gr.CheckboxGroup(list(prompt_options.keys()), label="Assign from input image", info="Checked : Assigned from the input images\nUnchecked : Assigned from the UI")
+                options = gr.Dropdown(list(prompt_options.keys()), label="Assign from input image", info="Select are assigned from the input, the rest from UI", multiselect = True)
 
                 gr.HTML("<p style=\"margin-bottom:0.75em\">Optional tags to remove or add in front/end of a positive prompt on all images</p>")
                 front_tags = gr.Textbox(label="Tags to add at the front")


### PR DESCRIPTION
Hi,

Switch from CheckboxGroup to Dropdown, the CheckboxGroup item settings aren't stored into the ui-config.json and Dropdown in multiselect feels better to use.

It's in the following of the issue #12, feel free to test it and decide by yourself the one you prefer. The issue was to define default values for the assign option, the CheckboxGroup doesn't appear in the file but Dropdown does.